### PR TITLE
refactor: stop inlining @vitejs/plugin-vue2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prepare": "simple-git-hooks"
   },
   "dependencies": {
+    "@vitejs/plugin-vue2": "^2.0.0",
     "@vue/compiler-sfc": "^2.7.10",
     "cac": "^6.7.14",
     "chokidar": "^3.5.3",
@@ -94,7 +95,6 @@
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.7.18",
     "@types/prompts": "^2.4.0",
-    "@vitejs/plugin-vue2": "^2.0.0",
     "bumpp": "^8.2.1",
     "eslint": "^8.23.1",
     "fast-glob": "^3.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ specifiers:
   vue: ^2.7.10
 
 dependencies:
+  '@vitejs/plugin-vue2': 2.0.0_vite@3.1.3+vue@2.7.10
   '@vue/compiler-sfc': 2.7.10
   cac: 6.7.14
   chokidar: 3.5.3
@@ -58,7 +59,6 @@ devDependencies:
   '@types/fs-extra': 9.0.13
   '@types/node': 18.7.18
   '@types/prompts': 2.4.0
-  '@vitejs/plugin-vue2': 2.0.0_vite@3.1.3+vue@2.7.10
   bumpp: 8.2.1
   eslint: 8.23.1
   fast-glob: 3.2.12
@@ -773,7 +773,7 @@ packages:
     dependencies:
       vite: 3.1.3_sass@1.54.9
       vue: 2.7.10
-    dev: true
+    dev: false
 
   /@vue/compiler-sfc/2.7.10:
     resolution: {integrity: sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==}
@@ -781,6 +781,7 @@ packages:
       '@babel/parser': 7.19.1
       postcss: 8.4.16
       source-map: 0.6.1
+    dev: false
 
   /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1078,6 +1079,7 @@ packages:
 
   /csstype/3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+    dev: false
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -3274,6 +3276,7 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -3665,6 +3668,7 @@ packages:
     dependencies:
       '@vue/compiler-sfc': 2.7.10
       csstype: 3.1.1
+    dev: false
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
Shouldn't be necessary anymore, now that the patch is removed

Btw, do you have any way of verifying that `npx` usage works pre-publishing, or is it a publish-and-hope-for-the-best situation?

(oh and btw2: Vite implemented actual `import.meta.hot.invalidate()` support [in the latest commit](https://github.com/vitejs/vite/commit/fb8ab1641feb597f5ba51f8e6e043d2ce3980e08) instead of always calling `location.reload()`, but I just checked, it still works the same for kirbyup 👍)