### PR TITLE
fix: set section flag independent from usedDef check

### DIFF
--- a/src/node/plugins/utils.ts
+++ b/src/node/plugins/utils.ts
@@ -50,6 +50,7 @@ export const isHmrRuntimeId = (id: string) => id === HMR_RUNTIME_ID || id === JS
  */
 
 export const __INJECTED_HMR_CODE__ = `
+/** - injected by kirbyup - */
 for (const methodName of ['rerender', 'reload']) {
   const original = __VUE_HMR_RUNTIME__[methodName]
 
@@ -64,10 +65,11 @@ for (const methodName of ['rerender', 'reload']) {
         if (updatedDef[key] === pluginComponents[componentName][key]) {
           const usedDefinition = usedComponentDefs[componentName].options
 
-          if (map[id].options !== usedDefinition) {
+          if (map[id].options !== usedDefinition)
             map[id].options = usedDefinition
+          
+          if (typeof map[id].options.$_isSection !== 'boolean')
             map[id].options.$_isSection = /^k-.*-section$/.test(componentName)
-          }
 
           break
         }
@@ -102,5 +104,5 @@ function $_applyKirbyModifications(activeDef, newDef) {
     else { newDef.extends = null }
   }
 }
-/** */
+/** -- */
 `


### PR DESCRIPTION
The `.$_isSection` flag (that's used to detect section components and re-apply the section mixin on HMR reload) was only added if the component definition held by the HMR runtime was stale. So if Kirby were to update its plugin code to mutate the component definition of section components instead of replacing it, the HMR plugin would break because the `map[id].options !== usedDefinition` condition wouldn't trigger anymore and the `.$_isSection` flag would not be set. Now, the flag is added independently from that condition, which is more sound.

Also, added the `/* injected by kirbyup */` banner again, which went missing during some refactor. (which is why the "end" comment looked lost and didn't make sense)