### PR TITLE
chore: push preversions to separate tag on npm

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -1,9 +1,10 @@
-name: Release
+name: Release Preversion
 
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      # only run for versions that have -something appended
+      - 'v[0-9]+.[0-9]+.[0-9]+-**'
 
 jobs:
   release:
@@ -27,7 +28,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: npm publish --access public --tag dev
+        run: npm publish --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
The release workflow that creates a prod release by pushing as `latest` to npm should only run for full versions like `v2.1.1`.

Added a separate workflow for preversions that pushes to npm under the `dev` tag. (or we can change it `next`, `preview`, whatever you like)