### PR TITLE
fix: Kirby 3.8.3 compat

### DIFF
--- a/src/node/plugins/utils.ts
+++ b/src/node/plugins/utils.ts
@@ -59,7 +59,7 @@ for (const methodName of ['rerender', 'reload']) {
 
     if (key) {
       const pluginComponents = window.panel.plugins.components
-      const usedComponentDefs = window.panel.$vue.$options.components
+      const usedComponentDefs = window.panel.$vue._vnode.componentInstance.$options.components
 
       for (const componentName in pluginComponents) {
         if (updatedDef[key] === pluginComponents[componentName][key]) {


### PR DESCRIPTION
I have no idea why, but when the `vuelidate` Vue plugin is registered before global components are, `$options.components` is empty (or rather only contains the Vue built-ins). This is the case [in Kirby 3.8.3+](https://github.com/getkirby/kirby/blob/7dcf359e3da2fa09923a3e0d851f2a74ae668e78/panel/src/index.js#L42), causing the HMR error #33.

Through some digging I found out that the components can still be found in `_vnode.componentInstance.$options.components`, so I changed the code to access them there. Works pre 3.8.3 too, so the change is backwards compatible.

fix #33